### PR TITLE
[UPDATE] retrieve photos

### DIFF
--- a/src/main/java/com/immobylette/api/main/exception/PhotoNotFoundException.java
+++ b/src/main/java/com/immobylette/api/main/exception/PhotoNotFoundException.java
@@ -3,11 +3,9 @@ package com.immobylette.api.main.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.UUID;
-
 @ResponseStatus(HttpStatus.NOT_FOUND)
 public class PhotoNotFoundException extends RuntimeException{
-    public PhotoNotFoundException(UUID id) {
+    public PhotoNotFoundException(String id) {
         super(String.format("Photo %s not found", id));
     }
 }

--- a/src/main/java/com/immobylette/api/main/mapper/ElementSummaryMapper.java
+++ b/src/main/java/com/immobylette/api/main/mapper/ElementSummaryMapper.java
@@ -13,12 +13,18 @@ public interface ElementSummaryMapper {
     @Mappings({
             @Mapping(target = "type", source = "element.elementType", qualifiedByName = "ElementType"),
             @Mapping(target = "nbBasePhotos", source = "nbBasePhotos"),
-            @Mapping(target = "nbPreviousPhotos", source = "nbPreviousPhotos")
+            @Mapping(target = "nbPreviousPhotos", source = "nbPreviousPhotos"),
+            @Mapping(target = "photo", source="element", qualifiedByName = "Photo")
     })
     ElementSummaryDto fromElement(Element element, int nbBasePhotos, int nbPreviousPhotos);
 
     @Named("ElementType")
     static String fromElementType(ElementType elementType) {
         return elementType.getLabel();
+    }
+
+    @Named("Photo")
+    static String fromPhoto(Element element) {
+        return String.format("%s/%s", element.getPhotoFolder().toString(), element.getPhoto().toString());
     }
 }

--- a/src/main/java/com/immobylette/api/main/resource/PhotoResource.java
+++ b/src/main/java/com/immobylette/api/main/resource/PhotoResource.java
@@ -28,18 +28,18 @@ public class PhotoResource {
     private final RestTemplate restTemplate;
 
     public PhotoUrlDto getPhoto(String id) throws PhotoNotFoundException, GCPStorageException {
-        ResponseEntity<PhotoDto> result = null;
-            result = restClient.get()
-                    .uri(String.format("api/v1/photos/%s", id))
-                    .retrieve()
-                    .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-                        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
-                            throw new PhotoNotFoundException(id);
-                        } else if (response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR) {
-                            throw new GCPStorageException("gcp error");
-                        }
-                    })
-                    .toEntity(PhotoUrlDto.class);
+        ResponseEntity<PhotoUrlDto> result = null;
+        result = restClient.get()
+                .uri(String.format("api/v1/photos/%s", id))
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                    if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+                        throw new PhotoNotFoundException(id);
+                    } else if (response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR) {
+                        throw new GCPStorageException("gcp error");
+                    }
+                })
+                .toEntity(PhotoUrlDto.class);
 
         return result.getBody();
     }

--- a/src/main/java/com/immobylette/api/main/resource/PhotoResource.java
+++ b/src/main/java/com/immobylette/api/main/resource/PhotoResource.java
@@ -27,18 +27,19 @@ public class PhotoResource {
     private final RestClient restClient;
     private final RestTemplate restTemplate;
 
-    public PhotoUrlDto getPhoto(UUID id) throws PhotoNotFoundException, GCPStorageException{
-        ResponseEntity<PhotoUrlDto> result = restClient.get()
-                .uri("/api/v1/photos/{id}", id)
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-                    if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
-                        throw new PhotoNotFoundException(id);
-                    } else if (response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR) {
-                        throw new GCPStorageException("gcp error");
-                    }
-                })
-                .toEntity(PhotoUrlDto.class);
+    public PhotoUrlDto getPhoto(String id) throws PhotoNotFoundException, GCPStorageException {
+        ResponseEntity<PhotoDto> result = null;
+            result = restClient.get()
+                    .uri(String.format("api/v1/photos/%s", id))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+                            throw new PhotoNotFoundException(id);
+                        } else if (response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR) {
+                            throw new GCPStorageException("gcp error");
+                        }
+                    })
+                    .toEntity(PhotoUrlDto.class);
 
         return result.getBody();
     }

--- a/src/main/java/com/immobylette/api/main/security/AuthenticationFilter.java
+++ b/src/main/java/com/immobylette/api/main/security/AuthenticationFilter.java
@@ -4,7 +4,6 @@ import com.immobylette.api.main.config.AuthConfig;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Base64;
 import lombok.AllArgsConstructor;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/immobylette/api/main/service/InventoryService.java
+++ b/src/main/java/com/immobylette/api/main/service/InventoryService.java
@@ -162,7 +162,9 @@ public class InventoryService {
                 labelState = inventoryLabelState.getStateLabel();
             }
 
-            elementSummaryDto.setPhoto("https://via.placeholder.com/150");
+            PhotoUrlDto photo = photoResource.getPhoto(elementSummaryDto.getPhoto());
+
+            elementSummaryDto.setPhoto(photo.getUrl());
             elementSummaryDto.setState(labelState);
             elementSummaryDto.setChecked(checked);
 
@@ -187,7 +189,9 @@ public class InventoryService {
             folderPreviousPhoto = folderResource.getFolder(steps.get(1).getRefPhotosFolder());
         }
 
-        PhotoUrlDto photo = photoResource.getPhoto(element.getPhoto());
+        String photoObjectName = String.format("%s/%s", element.getPhotoFolder().toString(), element.getPhoto().toString());
+
+        PhotoUrlDto photo = photoResource.getPhoto(photoObjectName);
         FolderDto folderBasePhoto = folderResource.getFolder(element.getPhotoFolder());
 
         return elementMapper.fromElement(element, photo, folderBasePhoto, folderPreviousPhoto);

--- a/src/main/java/com/immobylette/api/main/service/PropertyService.java
+++ b/src/main/java/com/immobylette/api/main/service/PropertyService.java
@@ -40,7 +40,7 @@ public class PropertyService {
         return properties.map(propertyDistance -> {
             Property property = propertyDistance.getProperty();
             Double distance = propertyDistance.getDistance();
-            PhotoUrlDto photo = photoResource.getPhoto(property.getPhoto());
+            PhotoUrlDto photo = photoResource.getPhoto(property.getPhoto().toString());
 
             ThirdParty currentTenant = thirdPartyRepository.findCurrentTenantByPropertyId(property.getId());
             UUID currentInventory = inventoryRepository.findCurrentInventoryByPropertyId(property.getId());
@@ -52,7 +52,7 @@ public class PropertyService {
         Property property = propertyRepository.findById(id).orElseThrow(() -> new PropertyNotFoundException(id));
         ThirdParty currentTenant = thirdPartyRepository.findCurrentTenantByPropertyId(id);
         UUID currentInventory = inventoryRepository.findCurrentInventoryByPropertyId(id);
-        PhotoUrlDto photo = photoResource.getPhoto(property.getPhoto());
+        PhotoUrlDto photo = photoResource.getPhoto(property.getPhoto().toString());
 
         return propertyMapper.fromProperty(property, currentTenant, photo, currentInventory);
     }

--- a/src/main/java/com/immobylette/api/main/service/ThirdPartyService.java
+++ b/src/main/java/com/immobylette/api/main/service/ThirdPartyService.java
@@ -27,7 +27,7 @@ public class ThirdPartyService {
     public List<ThirdPartyDto> getAgents() throws PhotoNotFoundException, GCPStorageException {
         List<ThirdParty> agents = thirdPartyRepository.findByThirdPartyTypeLabel(ThirdPartyTypeEnum.AGENT.getName());
         return agents.stream().map(agent -> {
-            PhotoUrlDto photo = photoResource.getPhoto(agent.getRefPhoto());
+            PhotoUrlDto photo = photoResource.getPhoto(agent.getRefPhoto().toString());
             return thirdPartyMapper.fromThirdParty(agent, photo);
         }).toList();
     }


### PR DESCRIPTION
Comme la photo de l'élément se situe dans le même dossier que les photos de base et n'est pas à part, j'ai du modifier un peu la méthode getPhoto de la resource.

Si l'on se situe dans le cas de la photo de l'élément alors le nom de l'objet que l'on souhaite récupérer ressemble à : 
{folderId}/{photoId} donc le param est maintenant un String et pour que le RestClient n'encode pas le "/" j'utilise désormais String.format

Concernant les éléments : 
- comme on réalise un "pré mapping" avant de récupérer les photos, pour gérer le cas de la photo de l'élément j'ai ajouté un mapper spéciale

J'ai modifié les PhotoException et les autres pour prendre un String à la place d'un UUID comme il y a un "/" dans l'objectName