### PR TITLE
[FIX] Checking if apiKey is null before checking IsEmpty (modificatio…

### DIFF
--- a/src/main/java/com/immobylette/api/main/controller/PropertyController.java
+++ b/src/main/java/com/immobylette/api/main/controller/PropertyController.java
@@ -40,8 +40,8 @@ public class PropertyController {
     }
 
     @PostMapping("/properties/{id}/start")
-    public UUID startInventory(@PathVariable UUID id,
-                               @RequestBody Map<String, UUID> dataAgent) throws PropertyNotAssociatedWithAnyLeaseException, AgentNotFoundException {
+    public UUID startInventory(@PathVariable UUID id, @RequestBody Map<String, UUID> dataAgent)
+            throws PropertyNotAssociatedWithAnyLeaseException, AgentNotFoundException, InventoryAlreadyInProgressException {
         return inventoryService.createInventory(id, dataAgent.get("agent"));
     }
 }

--- a/src/main/java/com/immobylette/api/main/exception/InventoryAlreadyInProgressException.java
+++ b/src/main/java/com/immobylette/api/main/exception/InventoryAlreadyInProgressException.java
@@ -1,0 +1,13 @@
+package com.immobylette.api.main.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.UUID;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class InventoryAlreadyInProgressException extends RuntimeException {
+    public InventoryAlreadyInProgressException(UUID id) {
+            super(String.format("An inventory is already in progress for the property : %s", id));
+        }
+}

--- a/src/main/java/com/immobylette/api/main/security/AuthenticationFilter.java
+++ b/src/main/java/com/immobylette/api/main/security/AuthenticationFilter.java
@@ -21,7 +21,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String apiKey = request.getHeader("X-Api-Key");
 
-        if (apiKey.isEmpty() || !apiKey.equals(authConfig.getApiKey())){
+        if (apiKey == null || apiKey.isEmpty() || !apiKey.equals(authConfig.getApiKey())){
             logger.error("Unauthorized");
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Access Denied");
             return;


### PR DESCRIPTION
…ns in database for properties recovery bug)

J'ai supprimé 4 lignes dans la table 'inventories' pour les états des lieux qui avaient plus d'un état des lieux d'entrée et plus d'un état des lieux de sortie associé à la même propriété. J'ai aussi supprimé 2 lignes de 'steps' qui avaient été crées sur ces états de lieux. 

J'ai ajouté un test sur la présence d'apiKey, car si on n'a pas fournit l'apiKey on avait une erreur Java car on essaye de faire un .IsEmpty sur une variable null, maintenant on a bien une erreur "Unauthorized".